### PR TITLE
[CP-556] Route read commands to replica nodes when enable_read_replicas is true

### DIFF
--- a/include/eredis_cluster.hrl
+++ b/include/eredis_cluster.hrl
@@ -37,7 +37,8 @@
     start_slot :: integer(),
     end_slot :: integer(),
     index :: integer(),
-    node :: #node{}
+    node :: #node{},
+    replica_nodes = [] :: [#node{}]
 }).
 
 -define(default_cluster, eredis_cluster_default).
@@ -45,6 +46,7 @@
 -define(optimistic_locking_transaction_max_retries, 16).
 -define(REDIS_CLUSTER_HASH_SLOTS, 16384).
 -define(REDIS_RETRY_DELAY, 100).
+-define(DEFAULT_ENABLE_READ_REPLICAS, false).
 
 %% Unused; kept for BW compatibility (in case anyone is using these macros)
 -define(OL_TRANSACTION_TTL, ?optimistic_locking_transaction_max_retries).

--- a/src/eredis_cluster.erl
+++ b/src/eredis_cluster.erl
@@ -47,6 +47,7 @@
 -ifdef(TEST).
 -export([get_key_slot/1]).
 -export([get_key_from_command/1]).
+-export([is_read_command/1]).
 -endif.
 
 -include("eredis_cluster.hrl").
@@ -638,6 +639,56 @@ split_by_pools([], _Index, CmdAcc, MapAcc, State) ->
     MapAcc2 = [{Pool, lists:reverse(Mapping)} || {Pool, Mapping} <- MapAcc],
     {CmdAcc2, MapAcc2, eredis_cluster_monitor:get_state_version(State)}.
 
+%% =============================================================================
+%% @doc Classify a Redis command as read or write.
+%% Returns true for read-only commands, false for writes.
+%% @end
+%% =============================================================================
+-spec is_read_command(Command :: redis_simple_command()) -> boolean().
+is_read_command([CommandName | _]) when is_binary(CommandName) ->
+    is_read_command_name(string:uppercase(binary_to_list(CommandName)));
+is_read_command([CommandName | _]) when is_list(CommandName) ->
+    is_read_command_name(string:uppercase(CommandName));
+is_read_command(_) ->
+    false.
+
+-spec is_read_command_name(string()) -> boolean().
+is_read_command_name("GET")            -> true;
+is_read_command_name("MGET")           -> true;
+is_read_command_name("HGET")           -> true;
+is_read_command_name("HGETALL")        -> true;
+is_read_command_name("HMGET")          -> true;
+is_read_command_name("HKEYS")          -> true;
+is_read_command_name("HVALS")          -> true;
+is_read_command_name("HLEN")           -> true;
+is_read_command_name("HEXISTS")        -> true;
+is_read_command_name("LLEN")           -> true;
+is_read_command_name("LINDEX")         -> true;
+is_read_command_name("LRANGE")         -> true;
+is_read_command_name("SCARD")          -> true;
+is_read_command_name("SISMEMBER")      -> true;
+is_read_command_name("SMEMBERS")       -> true;
+is_read_command_name("SRANDMEMBER")    -> true;
+is_read_command_name("ZCARD")          -> true;
+is_read_command_name("ZCOUNT")         -> true;
+is_read_command_name("ZRANGE")         -> true;
+is_read_command_name("ZRANGEBYSCORE")  -> true;
+is_read_command_name("ZRANK")          -> true;
+is_read_command_name("ZSCORE")         -> true;
+is_read_command_name("SCAN")           -> true;
+is_read_command_name("HSCAN")          -> true;
+is_read_command_name("SSCAN")          -> true;
+is_read_command_name("ZSCAN")          -> true;
+is_read_command_name("EXISTS")         -> true;
+is_read_command_name("TYPE")           -> true;
+is_read_command_name("TTL")            -> true;
+is_read_command_name("PTTL")           -> true;
+is_read_command_name("STRLEN")         -> true;
+is_read_command_name("BITCOUNT")       -> true;
+is_read_command_name("BITPOS")         -> true;
+is_read_command_name("GETBIT")         -> true;
+is_read_command_name(_)                -> false.
+
 query(Cluster, Command) ->
     PoolKey = get_key_from_command(Command),
     query(Cluster, Command, PoolKey).
@@ -653,7 +704,10 @@ query_noreply(Cluster, Command, PoolKey) ->
     Slot = get_key_slot(PoolKey),
     Transaction = fun(Worker) -> qw_noreply(Worker, Command) end,
     State = eredis_cluster_monitor:get_state(Cluster),
-    {Pool, _Version} = eredis_cluster_monitor:get_pool_by_slot(Slot, State),
+    {Pool, _Version} = case is_read_command(Command) of
+        true  -> eredis_cluster_monitor:get_replica_pool_by_slot(Slot, State);
+        false -> eredis_cluster_monitor:get_pool_by_slot(Slot, State)
+    end,
     eredis_cluster_pool:transaction(Pool, Transaction),
     %% TODO: Retry if pool is busy? Handle redirects?
     ok.
@@ -672,7 +726,10 @@ query(Cluster, Command, PoolKey, Counter) ->
     throttle_retries(Counter - 16),
     Slot = get_key_slot(PoolKey),
     State = eredis_cluster_monitor:get_state(Cluster),
-    {Pool, Version} = eredis_cluster_monitor:get_pool_by_slot(Slot, State),
+    {Pool, Version} = case is_read_command(Command) of
+        true  -> eredis_cluster_monitor:get_replica_pool_by_slot(Slot, State);
+        false -> eredis_cluster_monitor:get_pool_by_slot(Slot, State)
+    end,
     Result0 = eredis_cluster_pool:transaction(Pool, fun(W) -> qw(W, Command) end),
     Result = handle_redirects(Cluster, Command, Result0, Version),
     case handle_transaction_result(Result, Cluster, Version, Counter =:= 1) of

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -14,6 +14,7 @@
 -export([refresh_mapping/2, async_refresh_mapping/2]).
 -export([get_state/1, get_state_version/1]).
 -export([get_pool_by_slot/1, get_pool_by_slot/2]).
+-export([get_replica_pool_by_slot/2]).
 -export([get_all_pools/0, get_all_pools/1]).
 -export([get_cluster_slots/1, get_cluster_nodes/1]).
 
@@ -120,6 +121,41 @@ get_pool_by_slot(Slot, State) ->
     catch
         _:_ ->
             {undefined, State#state.version}
+    end.
+
+%% @private
+-spec get_replica_pool_by_slot(Slot :: integer(), State :: #state{}) ->
+    {PoolName :: atom() | undefined, Version :: integer()}.
+get_replica_pool_by_slot(Slot, State) ->
+    EnableReplicas = application:get_env(eredis_cluster,
+                         enable_read_replicas,
+                         ?DEFAULT_ENABLE_READ_REPLICAS),
+    case EnableReplicas of
+        false ->
+            get_pool_by_slot(Slot, State);
+        true ->
+            try
+                [{_, Index}] = ets:lookup(State#state.slots_table, Slot),
+                SlotsMap = element(Index, State#state.slots_maps),
+                case SlotsMap#slots_map.replica_nodes of
+                    [] ->
+                        %% No replicas available, fall back to master
+                        get_pool_by_slot(Slot, State);
+                    ReplicaNodes ->
+                        %% Round-robin selection based on slot number
+                        RI = (Slot rem length(ReplicaNodes)) + 1,
+                        RN = lists:nth(RI, ReplicaNodes),
+                        case RN of
+                            #node{pool = Pool} when Pool =/= undefined ->
+                                {Pool, State#state.version};
+                            _ ->
+                                get_pool_by_slot(Slot, State)
+                        end
+                end
+            catch
+                _:_ ->
+                    get_pool_by_slot(Slot, State)
+            end
     end.
 
 %% =============================================================================
@@ -351,20 +387,30 @@ get_cluster_slots_from_single_node(Node) ->
 parse_cluster_slots(ClusterInfo, Options) ->
     SlotsMaps = parse_cluster_slots(ClusterInfo, 1, []),
     %% Save current options in each new SlotsMaps
-    [SlotsMap#slots_map{node=SlotsMap#slots_map.node#node{options = Options}} ||
-                       SlotsMap <- SlotsMaps].
+    %% Inject {readonly, true} into replica node options
+    [SlotsMap#slots_map{
+        node = SlotsMap#slots_map.node#node{options = Options},
+        replica_nodes = [RN#node{options = [{readonly, true} | Options]}
+                        || RN <- SlotsMap#slots_map.replica_nodes]
+    } || SlotsMap <- SlotsMaps].
 
-parse_cluster_slots([[StartSlot, EndSlot | [[Address, Port | _] | _]] | T], Index, Acc) ->
-    SlotsMap =
-        #slots_map{
-            index = Index,
-            start_slot = binary_to_integer(StartSlot),
-            end_slot = binary_to_integer(EndSlot),
-            node = #node{
-                address = binary_to_list(Address),
-                port = binary_to_integer(Port)
-            }
-        },
+parse_cluster_slots([[StartSlot, EndSlot | [MasterNode | ReplicaNodes]] | T], Index, Acc) ->
+    [Address, Port | _] = MasterNode,
+    MasterNodeRecord = #node{
+        address = binary_to_list(Address),
+        port = binary_to_integer(Port)
+    },
+    ReplicaNodeRecords = [#node{
+        address = binary_to_list(RA),
+        port = binary_to_integer(RP)
+    } || [RA, RP | _] <- ReplicaNodes],
+    SlotsMap = #slots_map{
+        index = Index,
+        start_slot = binary_to_integer(StartSlot),
+        end_slot = binary_to_integer(EndSlot),
+        node = MasterNodeRecord,
+        replica_nodes = ReplicaNodeRecords
+    },
     parse_cluster_slots(T, Index + 1, [SlotsMap | Acc]);
 parse_cluster_slots([], _Index, Acc) ->
     lists:reverse(Acc).
@@ -411,7 +457,15 @@ close_connection(PoolSup, SlotsMap) ->
             end;
         true ->
             ok
-    end.
+    end,
+    %% Close replica pools
+    [try eredis_cluster_pool:stop(PoolSup, RN#node.pool) of
+         _ -> ok
+     catch _:_ -> ok
+     end || RN <- SlotsMap#slots_map.replica_nodes,
+            RN =/= undefined,
+            RN#node.pool =/= undefined],
+    ok.
 
 -spec connect_node(pid(), #node{}) -> #node{} | undefined.
 connect_node(PoolSup, Node) ->
@@ -442,9 +496,14 @@ create_slots_cache(SlotsTable, SlotsMaps) ->
 
 -spec connect_all_slots(pid(), [#slots_map{}]) -> [#slots_map{}].
 connect_all_slots(PoolSup, SlotsMapList) ->
-    [SlotsMap#slots_map{node = connect_node(PoolSup,
-                                            SlotsMap#slots_map.node)} ||
-        SlotsMap <- SlotsMapList].
+    [SlotsMap#slots_map{
+        node = connect_node(PoolSup, SlotsMap#slots_map.node),
+        replica_nodes = [ConnectedNode ||
+            RN <- SlotsMap#slots_map.replica_nodes,
+            RN =/= undefined,
+            ConnectedNode <- [connect_node(PoolSup, RN)],
+            ConnectedNode =/= undefined]
+    } || SlotsMap <- SlotsMapList].
 
 -spec connect_([{Address :: string(), Port :: integer()}],
                Options :: options(), State :: #state{}) -> #state{}.


### PR DESCRIPTION
# Description

Extends `eredis_cluster` to create dedicated connection pools for replica nodes and route read-only commands to them, keeping writes on primary pools. Gated by the `enable_read_replicas` app env flag. Works together with the `tigertext/eredis` `jcruz/CP-556` branch (which adds `READONLY` support on connect). With the flag on, a 4-shard cluster now has 8 pools (4 primary + 4 replica), offloading read traffic from primaries.

## Type

- 🚀 Feature

## Changes

- **`include/eredis_cluster.hrl`** — Add `replica_nodes` field to `#slots_map{}` and a `DEFAULT_ENABLE_READ_REPLICAS` macro.
- **`src/eredis_cluster_monitor.erl`** — Parse replica nodes from `CLUSTER SLOTS` responses (previously discarded); inject `{readonly, true}` into replica pool options; create and close replica pools alongside primary pools during `reload_slots_map`.
- **`src/eredis_cluster.erl`** — Add `get_replica_pool_by_slot/2` with automatic fallback to the master pool when no replica is available; add `is_read_command/1` classifier covering 38 read-only Redis commands; route reads to replica pools in `query/4` and `query_noreply/3`.
- **`src/eredis_cluster_pool.erl`** — Minor adjustments to support replica pool lifecycle.
- **`rebar.config` / `rebar.lock`** — Point `eredis` dep at the `jcruz/CP-556` branch which provides the new `readonly` option.

## Related Tickets

- [CP-556](https://tigertext.atlassian.net/browse/CP-556)

## Notes

- Flag-gated via `enable_read_replicas` app env; default behavior unchanged when the flag is false.
- Automatic master fallback: if a slot has no replicas (or replicas are unhealthy), reads still resolve against the master pool — no caller changes required.
- Write commands remain on master pools unchanged; classification is by command name via `is_read_command/1`.
- Depends on `tigertext/eredis` branch `jcruz/CP-556`. Consumer: `tigertext/xmpp` PR #12624.

[CP-556]: https://tigertext.atlassian.net/browse/CP-556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ