### PR TITLE
[CP-556] Honor per-cluster enable_read_replicas option

### DIFF
--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -127,9 +127,14 @@ get_pool_by_slot(Slot, State) ->
 -spec get_replica_pool_by_slot(Slot :: integer(), State :: #state{}) ->
     {PoolName :: atom() | undefined, Version :: integer()}.
 get_replica_pool_by_slot(Slot, State) ->
-    EnableReplicas = application:get_env(eredis_cluster,
-                         enable_read_replicas,
-                         ?DEFAULT_ENABLE_READ_REPLICAS),
+    %% Per-cluster opt-in: an `{enable_read_replicas, true}' entry passed via
+    %% the connect/3 Options list takes precedence over the OTP app env,
+    %% since get_current_options/1 merges node_options ahead of the env via
+    %% lists:ukeysort/2. Falls back to env, then to ?DEFAULT_ENABLE_READ_REPLICAS.
+    Options = get_current_options(State),
+    EnableReplicas = proplists:get_value(enable_read_replicas,
+                                         Options,
+                                         ?DEFAULT_ENABLE_READ_REPLICAS),
     case EnableReplicas of
         false ->
             get_pool_by_slot(Slot, State);


### PR DESCRIPTION
# Description

Follow-up to #24. The previous change made `get_replica_pool_by_slot/2` read `enable_read_replicas` directly from the `eredis_cluster` OTP app env, which forces the flag to apply to **every** cluster managed by the lib. This PR makes the flag respect the per-cluster `Options` list passed to `connect/3` so consumers can scope the rollout one cluster at a time.

## Type

- 🔨 Refactor
- 🚀 Feature

## Changes

- **`src/eredis_cluster_monitor.erl`** — In `get_replica_pool_by_slot/2`, replace the direct `application:get_env/3` lookup with `proplists:get_value/3` over `get_current_options(State)`. Because `get_current_options/1` merges `State#state.node_options` ahead of the env via `lists:ukeysort/2`, an `{enable_read_replicas, true}` entry passed in the per-cluster `Options` list now wins over (or supplies) the value. Falls back to env, then to `?DEFAULT_ENABLE_READ_REPLICAS` (`false`) — fully backward compatible.

## Related Tickets

- [CP-556](https://tigertext.atlassian.net/browse/CP-556)

## Notes

- No public-API changes. `connect/3` already accepted an `Options` list; this PR just makes the lib honor it for `enable_read_replicas`.
- Default behavior unchanged: a cluster connected without the option (and with no app env set) keeps using master pools for reads.
- Motivation: scope MemoryDB read-replica routing in `tigertext/xmpp` to the roster cluster only for the initial rollout, leaving the other 5 clusters (omnious, platform, resource_queue, message_db, group_db) unaffected until each is independently validated.

[CP-556]: https://tigertext.atlassian.net/browse/CP-556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ