### PR TITLE
[CP-556] Gate replica pool creation by enable_read_replicas

### DIFF
--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -391,12 +391,25 @@ get_cluster_slots_from_single_node(Node) ->
                           Options::options()) -> [#slots_map{}].
 parse_cluster_slots(ClusterInfo, Options) ->
     SlotsMaps = parse_cluster_slots(ClusterInfo, 1, []),
+    %% Per-cluster gate: when enable_read_replicas is disabled for this
+    %% cluster (the default), drop replicas at parse time so no replica pools
+    %% are ever created and no connections are opened to replica nodes.
+    %% Without this gate the lib would still open replica connections on
+    %% every cluster, just not route reads to them.
+    EnableReplicas = proplists:get_value(enable_read_replicas,
+                                         Options,
+                                         ?DEFAULT_ENABLE_READ_REPLICAS),
     %% Save current options in each new SlotsMaps
     %% Inject {readonly, true} into replica node options
     [SlotsMap#slots_map{
         node = SlotsMap#slots_map.node#node{options = Options},
-        replica_nodes = [RN#node{options = [{readonly, true} | Options]}
-                        || RN <- SlotsMap#slots_map.replica_nodes]
+        replica_nodes = case EnableReplicas of
+                            true ->
+                                [RN#node{options = [{readonly, true} | Options]}
+                                 || RN <- SlotsMap#slots_map.replica_nodes];
+                            false ->
+                                []
+                        end
     } || SlotsMap <- SlotsMaps].
 
 parse_cluster_slots([[StartSlot, EndSlot | [MasterNode | ReplicaNodes]] | T], Index, Acc) ->


### PR DESCRIPTION
# Description

Follow-up to #25. The earlier per-cluster opt-in only scoped *read-command routing* — pool creation still iterated the replica nodes parsed from `CLUSTER SLOTS` on every cluster, opening replica connections regardless of the flag. Confirmed in lt2: every MemoryDB cluster showed connections on its replica nodes, not just the roster cluster that opted in.

This moves the gate up to `parse_cluster_slots/2` (which already receives the merged per-cluster options), so when `enable_read_replicas` is false (the default), replica nodes are dropped at parse time. Downstream, `connect_all_slots/2` has nothing to connect to and no replica pools are created. The routing site already falls back to master when `replica_nodes` is empty, so reads continue to work unchanged on opted-out clusters.

## Type

- 🐞 Bug Fix

## Changes

- **`src/eredis_cluster_monitor.erl`** (`parse_cluster_slots/2`) — Read `enable_read_replicas` from the merged options; when false, set `replica_nodes = []` for every slots map. When true, behavior is unchanged from #25 (replicas preserved with `{readonly, true}` injected into options).

## Related Tickets

- [CP-556](https://tigertext.atlassian.net/browse/CP-556)

## Notes

- Default of `?DEFAULT_ENABLE_READ_REPLICAS` is `false`, so any cluster that hasn't explicitly opted in via `connect/3` Options gets zero replica connections.
- The flag check inside `get_replica_pool_by_slot/2` is now effectively redundant for opted-out clusters (empty `replica_nodes` already triggers master fallback), but it's left in place as defense-in-depth and for clarity at the routing call site.
- No public API change.

[CP-556]: https://tigertext.atlassian.net/browse/CP-556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ