### PR TITLE
[CP-639] Configurable connect timeout + startup timing logs

### DIFF
--- a/include/eredis_cluster.hrl
+++ b/include/eredis_cluster.hrl
@@ -47,6 +47,7 @@
 -define(REDIS_CLUSTER_HASH_SLOTS, 16384).
 -define(REDIS_RETRY_DELAY, 100).
 -define(DEFAULT_ENABLE_READ_REPLICAS, false).
+-define(CONNECT_TIMEOUT_DEFAULT, 60_000).
 
 %% Unused; kept for BW compatibility (in case anyone is using these macros)
 -define(OL_TRANSACTION_TTL, ?optimistic_locking_transaction_max_retries).

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -52,7 +52,15 @@ start_link(Cluster) ->
 
 %% @private
 connect(Cluster, InitServers, Options) ->
-    gen_server:call(?cluster_process(Cluster), {connect, InitServers, Options}).
+    %% connect_timeout is a call-level option, not a per-connection option.
+    %% Extract it for use with gen_server:call/3 and strip from Options before
+    %% forwarding so it doesn't pollute eredis worker start_link options.
+    Timeout = proplists:get_value(connect_timeout, Options,
+                                  ?CONNECT_TIMEOUT_DEFAULT),
+    CleanOptions = proplists:delete(connect_timeout, Options),
+    gen_server:call(?cluster_process(Cluster),
+                    {connect, InitServers, CleanOptions},
+                    Timeout).
 
 %% @private
 disconnect(Cluster, PoolNodes) ->
@@ -487,15 +495,21 @@ close_connection(PoolSup, SlotsMap) ->
 
 -spec connect_node(pid(), #node{}) -> #node{} | undefined.
 connect_node(PoolSup, Node) ->
-    case eredis_cluster_pool:create(PoolSup,
-                                    Node#node.address,
-                                    Node#node.port,
-                                    Node#node.options) of
-        {ok, Pool} ->
-            Node#node{pool=Pool};
-        _ ->
-            undefined
-    end.
+    T0 = erlang:monotonic_time(millisecond),
+    Result = case eredis_cluster_pool:create(PoolSup,
+                                             Node#node.address,
+                                             Node#node.port,
+                                             Node#node.options) of
+                 {ok, Pool} ->
+                     Node#node{pool=Pool};
+                 _ ->
+                     undefined
+             end,
+    T1 = erlang:monotonic_time(millisecond),
+    Readonly = proplists:get_value(readonly, Node#node.options, false),
+    lager:info("[eredis_cluster] node ~s:~p (readonly=~p) pool create took ~p ms",
+               [Node#node.address, Node#node.port, Readonly, T1 - T0]),
+    Result.
 
 safe_eredis_start_link(Address, Port, Options) ->
     process_flag(trap_exit, true),
@@ -514,14 +528,29 @@ create_slots_cache(SlotsTable, SlotsMaps) ->
 
 -spec connect_all_slots(pid(), [#slots_map{}]) -> [#slots_map{}].
 connect_all_slots(PoolSup, SlotsMapList) ->
-    [SlotsMap#slots_map{
-        node = connect_node(PoolSup, SlotsMap#slots_map.node),
-        replica_nodes = [ConnectedNode ||
-            RN <- SlotsMap#slots_map.replica_nodes,
-            RN =/= undefined,
-            ConnectedNode <- [connect_node(PoolSup, RN)],
-            ConnectedNode =/= undefined]
-    } || SlotsMap <- SlotsMapList].
+    Cluster = this_cluster(),
+    lists:map(
+      fun(SlotsMap) ->
+              T0 = erlang:monotonic_time(millisecond),
+              Connected = SlotsMap#slots_map{
+                  node = connect_node(PoolSup, SlotsMap#slots_map.node),
+                  replica_nodes = [ConnectedNode ||
+                      RN <- SlotsMap#slots_map.replica_nodes,
+                      RN =/= undefined,
+                      ConnectedNode <- [connect_node(PoolSup, RN)],
+                      ConnectedNode =/= undefined]
+              },
+              T1 = erlang:monotonic_time(millisecond),
+              lager:info("[eredis_cluster] cluster ~p shard ~p connected in ~p ms "
+                         "(slot_range=~p-~p, replicas=~p)",
+                         [Cluster,
+                          SlotsMap#slots_map.index,
+                          T1 - T0,
+                          SlotsMap#slots_map.start_slot,
+                          SlotsMap#slots_map.end_slot,
+                          length(Connected#slots_map.replica_nodes)]),
+              Connected
+      end, SlotsMapList).
 
 -spec connect_([{Address :: string(), Port :: integer()}],
                Options :: options(), State :: #state{}) -> #state{}.
@@ -532,8 +561,13 @@ connect_(InitNodes, Options, State) ->
         init_nodes = [#node{address = A, port = P} || {A, P} <- InitNodes],
         node_options = Options
     },
-
-    reload_slots_map(NewState).
+    T0 = erlang:monotonic_time(millisecond),
+    Result = reload_slots_map(NewState),
+    T1 = erlang:monotonic_time(millisecond),
+    lager:info("[eredis_cluster] cluster ~p connect finished in ~p ms "
+               "(init_nodes=~p, options=~p)",
+               [this_cluster(), T1 - T0, length(InitNodes), Options]),
+    Result.
 
 -spec disconnect_(PoolNodes :: [atom()], State :: #state{}) -> #state{}.
 disconnect_([], State) ->


### PR DESCRIPTION
# Description

Fixes a startup crash observed on the prod canary after the CP-556 read-replica work landed:

```
{timeout, {gen_server, call, [memorydb_for_roster_db,
  {connect, [{\"clustercfg.xmpp-roster-memorydb-prod...\", 6379}],
   [{pool_max_overflow,50},{pool_size,75},{enable_read_replicas,true}]}]}}
```

Root cause: `eredis_cluster_monitor:connect/3` used `gen_server:call/2` (5-second default). The handler synchronously parses `CLUSTER SLOTS` and then `connect_all_slots/2` opens every pool sequentially; inside each pool, poolboy boots its `pool_size` workers and each worker does a TCP + TLS handshake to MemoryDB. With replicas enabled on the prod roster cluster (8 shards × 2 nodes × 75 workers = **1200 sequential TLS handshakes**), 5 seconds is not enough. lt2 (2 shards × 2 × 75 = 300) just barely fit; prod doesn't.

This PR:

1. Makes the connect-call timeout configurable per cluster via a `{connect_timeout, Millis}` entry in the Options list passed to `eredis_cluster:connect/3`. Default is `?CONNECT_TIMEOUT_DEFAULT = 60_000` — strictly more permissive than today's effective 5s, so no existing caller breaks.
2. Strips `connect_timeout` from Options before forwarding into `node_options`, so it doesn't leak into per-connection eredis worker `start_link` options.
3. Adds `lager:info` timing brackets to the connect path so we can measure real boot durations on env7 (now scaled to 16 nodes matching prod) before tuning further:
   - **node-level**: `[eredis_cluster] node <host>:<port> (readonly=...) pool create took N ms` — one per node, finest grain.
   - **shard-level**: `[eredis_cluster] cluster <name> shard <idx> connected in N ms (slot_range=A-B, replicas=R)` — one per shard.
   - **cluster-level**: `[eredis_cluster] cluster <name> connect finished in N ms (init_nodes=N, options=O)` — one per cluster, top-level total.

## Type

- 🐞 Bug Fix
- ✨ Optimization

## Changes

- **`include/eredis_cluster.hrl`** — Add `?CONNECT_TIMEOUT_DEFAULT = 60_000` next to `?DEFAULT_ENABLE_READ_REPLICAS`.
- **`src/eredis_cluster_monitor.erl`**:
  - `connect/3` extracts `connect_timeout` from Options (default 60s), strips it, and uses `gen_server:call/3`.
  - `connect_/3` wraps `reload_slots_map/1` with monotonic-time bracket and a top-level summary log.
  - `connect_all_slots/2` refactored from list comprehension to `lists:map/2` so each shard can be timed separately.
  - `connect_node/2` brackets `eredis_cluster_pool:create/4` with monotonic-time and logs per-node + readonly flag.

## Related Tickets

- [CP-639](https://tigertext.atlassian.net/browse/CP-639) — follow-up to CP-556

## Notes

- All new log lines use the `[eredis_cluster]` prefix to make grep/filter easy on env7.
- Default of 60s applies to **all** callers (not just opt-in). Strictly more permissive — slower failure detection on broken clusters at startup, but won't break healthy ones.
- Pool sizes are intentionally **not** changed in this PR. The user wants timing data from env7 first before deciding whether replica pools should be sized differently.
- Companion change in `tigertext/xmpp` (`jcruz/CP-639`) explicitly passes `{connect_timeout, 60_000}` to the roster connect call for auditability at the call site.

[CP-639]: https://tigertext.atlassian.net/browse/CP-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ