### PR TITLE
[CP-648] Remove auto-reconnect from query/q1 exhausted-retry paths

### DIFF
--- a/src/eredis_cluster.erl
+++ b/src/eredis_cluster.erl
@@ -200,24 +200,19 @@ q1(Cluster, Command, 0) ->
     end,
     {error, no_connection};
 q1(Cluster, Command, Count) when Count > 0 ->
+    %% CP-648: do NOT call reconnect/1 from these exception handlers.
+    %% The {connect,...} handler in eredis_cluster_monitor is not idempotent
+    %% under concurrency, so N exhausted callers all serializing through it
+    %% triggers a thundering-herd reconnect storm (root cause of the
+    %% xmpp-roles-prod / xmpp-group-prod OOM on 2026-06-04). Recovery from
+    %% transient node failures already happens through the version-protected
+    %% refresh_mapping path inside query/4's handle_transaction_result.
     try
         query(Cluster, Command)
     catch
         exit:{noproc,_}:_Trace ->
-            try
-                reconnect(Cluster)
-            catch
-                _E:_R ->
-                    ok
-            end,
             q1(Cluster, Command, Count - 1);
         _Error:_Reason:_Trace ->
-            try
-                reconnect(Cluster)
-            catch
-                _E:_R ->
-                    ok
-            end,
             q1(Cluster, Command, Count - 1)
     end.
 
@@ -713,8 +708,14 @@ query_noreply(Cluster, Command, PoolKey) ->
     ok.
 
 query(Cluster, Command, _PoolKey, 0) ->
+    %% CP-648: removed the implicit reconnect(Cluster) call. See the q1/3
+    %% comment above and the 2026-06-04 incident: the unprotected
+    %% {connect,...} gen_server handler made concurrent reconnects from N
+    %% exhausted workers create new pools without bound, OOM'ing the task.
+    %% Match upstream Nordix/eredis_cluster 0.9.0 behavior here: report the
+    %% failure and return {error, no_connection}. Explicit recovery still
+    %% available via eredis_cluster:reconnect/1 from operational code.
     try
-        reconnect(Cluster),
         tt_prometheus:report_failed_write_for_resource_queue("write_failed_reach_max_times", Cluster)
     catch
         _E:_R ->


### PR DESCRIPTION
## Summary

When a query's poolboy retries exhaust, the TC fork was calling `reconnect/1`, which serializes through `eredis_cluster_monitor`'s `{connect, InitServers, Options}` `gen_server` handler. That handler has no version-check protection (unlike `{reload_slots_map, Version}`), so N concurrent exhausted callers all execute a full `reload_slots_map`, flooding the monitor's mailbox and the lager handler.

This triggered an OOM on `xmpp-roles-prod` and `xmpp-group-prod` on **2026-06-04** when an anomalous bulk SQS message exhausted the pool across many wpool workers simultaneously (319,891 `connect_node` calls in a single task; the other 19 tasks each saw 439 cascading calls and also OOM'd).

Incident report: https://tigertext.atlassian.net/wiki/spaces/~62852e7782e85d0068f42ff3/pages/4736155651

## Change

Two surgical edits in `src/eredis_cluster.erl`:

1. **`query/4` at counter=0** — removed the implicit `reconnect(Cluster)` call. Now matches upstream Nordix/eredis_cluster 0.9.0 behavior: report the metric and return `{error, no_connection}`.
2. **`q1/3` (Count > 0)** — removed the `reconnect/1` calls from both exception handlers (`exit:{noproc,_}` and the catch-all). The retry-decrement path remains.

`reconnect/1` and its export remain — operational scripts (pool resize, etc.) can still call it explicitly.

## Why this is safe

`handle_transaction_result` inside `query/4` already triggers `refresh_mapping/2` on connection-related errors (`no_connection`, `tcp_closed`, generic posix errors). `refresh_mapping/2` routes through `{reload_slots_map, Version}`, which IS version-protected — concurrent calls after the first one are no-ops. So legitimate "node went away" recovery still happens; we just stop firing the unprotected reconnect path on every exhausted query.

## What this PR does NOT do (intentional)

- **No idempotency fix in `handle_call({connect,...})`** — that's a larger semantic change for a separate PR. With CP-648 in place, nothing else in the lib auto-calls `{connect,...}`, so the unprotected handler is no longer reachable from a hot path.
- **No new CT tests** — the lib's existing suite has no reconnect-storm coverage. Adding one requires a fakeredis harness simulating N concurrent `pool_busy`. Will file as a follow-up.

## Test plan

- [ ] xmpp companion PR (#TBD) bumps `rebar.lock` to this branch and deploys to env7/lt2 for verification
- [ ] On env7/lt2, simulate pool exhaustion (small `pool_size`, many concurrent workers) and confirm no `connect_node` log storm
- [ ] Verify `eredis_cluster:reconnect/1` still works when called explicitly from an Erlang shell
- [ ] Existing CT suites: `make ct` (no behavior change for the happy paths)